### PR TITLE
Fixed crash when trying to compare to an object of another class

### DIFF
--- a/SWFSemanticVersion/SWFSemanticVersion.m
+++ b/SWFSemanticVersion/SWFSemanticVersion.m
@@ -132,7 +132,14 @@
 
 - (BOOL)isEqual:(id)object
 {
-    return [self compare:object] == NSOrderedSame;
+    if([object isKindOfClass:self.class])
+    {
+        return [self compare:object] == NSOrderedSame;
+    }
+    else
+    {
+        return NO;
+    }
 }
 
 - (NSComparisonResult)compare:(SWFSemanticVersion *)version

--- a/SWFSemanticVersionTests/SWFSemanticVersionTests.m
+++ b/SWFSemanticVersionTests/SWFSemanticVersionTests.m
@@ -169,6 +169,7 @@
     
     XCTAssert([b1a isEqual:b1b]);
     XCTAssertFalse([b1a isEqual:b2]);
+    XCTAssertFalse([b1a isEqual:NSNull.null]);
 }
 
 @end


### PR DESCRIPTION
I've tried using this pod with Mantle (https://github.com/Mantle/Mantle) and Mantle compares the parsed object with NSNull.null. This caused a crash as the equality check never check the object it compares with. This should fix the issue.

Also added an assert for this in test.

Thanks.
