### PR TITLE
Update regex to support partial versions

### DIFF
--- a/SWFSemanticVersion/SWFSemanticVersion.m
+++ b/SWFSemanticVersion/SWFSemanticVersion.m
@@ -62,7 +62,7 @@
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSError *error;
-        _regex = [NSRegularExpression regularExpressionWithPattern:@"\\A(\\d+\\.\\d+\\.\\d+)(-([0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*))?(\\+([0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*))?\\Z" options:0 error:&error];
+        _regex = [NSRegularExpression regularExpressionWithPattern:@"\\A(\\d+\\.\\d+\\.\\d+)(-([0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*))?(\\+([0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*))?\\Z|\\A(\\d+)\\Z|\\A(\\d+\\.\\d+)\\Z" options:0 error:&error];
     });
     return _regex;
 }

--- a/SWFSemanticVersionTests/SWFSemanticVersionTests.m
+++ b/SWFSemanticVersionTests/SWFSemanticVersionTests.m
@@ -25,6 +25,26 @@
     [super tearDown];
 }
 
+- (void)testSimplestPartialVersion
+{
+    SWFSemanticVersion *semVer = [SWFSemanticVersion semanticVersionWithString:@"1"];
+    
+    XCTAssert(semVer, @"where are you, semVer?");
+    XCTAssertEqualObjects(@1, semVer.major);
+    XCTAssertEqualObjects(@0, semVer.minor);
+    XCTAssertEqualObjects(@0, semVer.patch);
+}
+
+- (void)testPartialVersion
+{
+    SWFSemanticVersion *semVer = [SWFSemanticVersion semanticVersionWithString:@"2.1"];
+    
+    XCTAssert(semVer, @"where are you, semVer?");
+    XCTAssertEqualObjects(@2, semVer.major);
+    XCTAssertEqualObjects(@1, semVer.minor);
+    XCTAssertEqualObjects(@0, semVer.patch);
+}
+
 - (void)testSimplestVersion
 {
     SWFSemanticVersion *semVer = [SWFSemanticVersion semanticVersionWithString:@"0.1.0"];
@@ -32,6 +52,13 @@
     XCTAssert(semVer, @"where are you, semVer?");
     XCTAssertEqualObjects(@0, semVer.major);
     XCTAssertEqualObjects(@1, semVer.minor);
+}
+
+- (void)testInvalidPartialVersion
+{
+    SWFSemanticVersion *semVer = [SWFSemanticVersion semanticVersionWithString:@"1-beta"];
+    
+    XCTAssertNil(semVer, @"wha?");
 }
 
 - (void)testInvalidVersionsAreNil


### PR DESCRIPTION
Naive regex update to support partial version numbers strings like "1" and "2.1"
